### PR TITLE
`Display`, and `Eq` for `index::Mime`

### DIFF
--- a/benches/mime_parse.rs
+++ b/benches/mime_parse.rs
@@ -23,7 +23,7 @@ fn benchmarks(c: &mut Criterion) {
         .measurement_time(Duration::from_millis(100));
 
     group.bench_function("StrMime literal (text/plain)", |b| {
-        b.iter(|| StrMime::new("text", "plain", None, None, None))
+        b.iter(|| StrMime::new("text", "plain", None, None, None));
     });
 
     group.bench_function("StrMime literal (text/plain; charset=utf-8)", |b| {
@@ -35,23 +35,23 @@ fn benchmarks(c: &mut Criterion) {
                 Some(StrParameter::new("charset", "utf-8").unwrap()),
                 None,
             )
-        })
+        });
     });
 
     group.bench_function("StrMime literal (image/svg+xml)", |b| {
-        b.iter(|| StrMime::new("image", "svg+xml", Some("xml"), None, None))
+        b.iter(|| StrMime::new("image", "svg+xml", Some("xml"), None, None));
     });
 
     group.bench_function("parse text/plain", |b| {
-        b.iter(|| IndexMime::constant("text/plain"))
+        b.iter(|| IndexMime::constant("text/plain"));
     });
 
     group.bench_function("parse text/plain; charset=utf-8", |b| {
-        b.iter(|| IndexMime::constant("text/plain; charset=utf-8"))
+        b.iter(|| IndexMime::constant("text/plain; charset=utf-8"));
     });
 
     group.bench_function("parse image/svg+xml", |b| {
-        b.iter(|| IndexMime::constant("image/svg+xml"))
+        b.iter(|| IndexMime::constant("image/svg+xml"));
     });
 
     group.finish();

--- a/benches/mime_type.rs
+++ b/benches/mime_type.rs
@@ -114,7 +114,7 @@ const STR_MIME_TEXT: StrMime =
 const STR_MIME_SVG: StrMime =
     StrMime { type_: "image", subtype: "svg+xml", suffix: Some("xml") };
 
-fn test_mime<M: Mime>(text: M, svg: M) {
+fn test_mime<M: Mime>(text: &M, svg: &M) {
     assert_eq!(black_box(text.type_()), "text");
     assert_eq!(black_box(text.subtype()), "plain");
     assert_eq!(black_box(text.suffix()), None);
@@ -136,27 +136,27 @@ fn benchmarks(c: &mut Criterion) {
 
     group.bench_function(
         BenchmarkId::new("u8", size_of_val(&INDEX_MIME_TEXT_U8)),
-        |b| b.iter(|| test_mime(INDEX_MIME_TEXT_U8, INDEX_MIME_SVG_U8)),
+        |b| b.iter(|| test_mime(&INDEX_MIME_TEXT_U8, &INDEX_MIME_SVG_U8)),
     );
     group.bench_function(
         BenchmarkId::new("u16", size_of_val(&INDEX_MIME_TEXT_U16)),
-        |b| b.iter(|| test_mime(INDEX_MIME_TEXT_U16, INDEX_MIME_SVG_U16)),
+        |b| b.iter(|| test_mime(&INDEX_MIME_TEXT_U16, &INDEX_MIME_SVG_U16)),
     );
     group.bench_function(
         BenchmarkId::new("usize", size_of_val(&INDEX_MIME_TEXT_USIZE)),
-        |b| b.iter(|| test_mime(INDEX_MIME_TEXT_USIZE, INDEX_MIME_SVG_USIZE)),
+        |b| b.iter(|| test_mime(&INDEX_MIME_TEXT_USIZE, &INDEX_MIME_SVG_USIZE)),
     );
     group.bench_function(
         BenchmarkId::new("str", size_of_val(&STR_MIME_TEXT)),
-        |b| b.iter(|| test_mime(STR_MIME_TEXT, STR_MIME_SVG)),
+        |b| b.iter(|| test_mime(&STR_MIME_TEXT, &STR_MIME_SVG)),
     );
     // Verify that benchmarks are working — this should take roughly twice as
     // long as the others.
     group.bench_function(BenchmarkId::new("control", 0), |b| {
         b.iter(|| {
-            test_mime(STR_MIME_TEXT, STR_MIME_SVG);
-            test_mime(INDEX_MIME_TEXT_USIZE, INDEX_MIME_SVG_USIZE);
-        })
+            test_mime(&STR_MIME_TEXT, &STR_MIME_SVG);
+            test_mime(&INDEX_MIME_TEXT_USIZE, &INDEX_MIME_SVG_USIZE);
+        });
     });
 
     group.finish();

--- a/src/index.rs
+++ b/src/index.rs
@@ -34,6 +34,7 @@ impl<'a> Mime<'a> {
     ///     );
     /// }
     /// ```
+    #[must_use]
     pub const fn constant(input: &'a str) -> Self {
         // Can’t use `try_constant()` because Self might be dropped.
         match Parser::type_parser().parse_const(input) {
@@ -100,20 +101,24 @@ impl<'a> Mime<'a> {
         )
     }
 
+    #[must_use]
     pub fn type_(&self) -> &str {
         &self.source.as_str()[0..self.slash.into()]
     }
 
+    #[must_use]
     pub fn subtype(&self) -> &str {
         &self.source.as_str()[usize::from(self.slash) + 1..self.end.into()]
     }
 
+    #[must_use]
     pub fn suffix(&self) -> Option<&str> {
         self.plus.map(|plus| {
             &self.source.as_str()[usize::from(plus) + 1..self.end.into()]
         })
     }
 
+    #[must_use]
     pub fn parameters(&'a self) -> ParameterIter<'a> {
         ParameterIter {
             source: &self.source,

--- a/src/index.rs
+++ b/src/index.rs
@@ -127,7 +127,7 @@ impl<'a> Mime<'a> {
     }
 }
 
-impl<'a> fmt::Display for Mime<'a> {
+impl fmt::Display for Mime<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}/{}", self.type_(), self.subtype())?;
         for (key, value) in self.parameters() {

--- a/src/rfc7231/mod.rs
+++ b/src/rfc7231/mod.rs
@@ -338,6 +338,7 @@ const fn parse_parameter_key_value(
 ///
 /// If the `usize` is larger than [`u16::MAX`].
 #[inline]
+#[allow(clippy::cast_possible_truncation)] // We check `src.len() < u16::MAX`
 const fn as_u16(i: usize) -> u16 {
     debug_assert!(i <= u16::MAX as usize, "as_u16 overflow");
     i as u16

--- a/src/rfc7231/quoted_string.rs
+++ b/src/rfc7231/quoted_string.rs
@@ -106,7 +106,8 @@ pub(crate) const fn parse_quoted_string(
 /// The only uses for the backslash escape are quotes and backslashes.
 ///
 /// [RFC7230 (HTTP) §3.2.6]: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6
-pub fn unquote_string<'a>(input: &'a str) -> Cow<'a, str> {
+#[must_use]
+pub fn unquote_string(input: &str) -> Cow<'_, str> {
     if let Some(i) = input.find('\\') {
         // FIXME? This will probably over-allocate a bit.
         let mut output = String::with_capacity(input.len() - 1);
@@ -148,7 +149,7 @@ mod tests {
 
     #[test]
     fn quoted_string_backslash_n() {
-        assert_eq!(unquote_string(r#"\n"#), "n");
+        assert_eq!(unquote_string(r"\n"), "n");
     }
 
     #[test]
@@ -158,7 +159,7 @@ mod tests {
 
     #[test]
     fn quoted_string_backslash_backslash() {
-        assert_eq!(unquote_string(r#"a\\b"#), r#"a\b"#);
+        assert_eq!(unquote_string(r"a\\b"), r"a\b");
     }
 
     #[test]
@@ -168,6 +169,6 @@ mod tests {
 
     #[test]
     fn quoted_string_unicode() {
-        assert_eq!(unquote_string(r#"\🙂"#), r#"🙂"#);
+        assert_eq!(unquote_string(r"\🙂"), r"🙂");
     }
 }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -101,19 +101,23 @@ impl Mime {
         self
     }
 
+    #[must_use]
     pub const fn type_(&self) -> &str {
         self.type_
     }
 
+    #[must_use]
     pub const fn subtype(&self) -> &str {
         self.subtype
     }
 
+    #[must_use]
     pub const fn suffix(&self) -> Option<&str> {
         self.suffix
     }
 
-    pub fn parameters<'a>(&'a self) -> ParameterIter<'a> {
+    #[must_use]
+    pub fn parameters(&self) -> ParameterIter<'_> {
         ParameterIter { parameters: &self.parameters, index: 0 }
     }
 }
@@ -190,10 +194,12 @@ impl Parameter {
         }
     }
 
+    #[must_use]
     pub const fn name(&self) -> &str {
         self.name
     }
 
+    #[must_use]
     pub const fn value(&self) -> &str {
         self.value
     }

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -1,41 +1,68 @@
 //! Test behavior of [`mime_const::index::Mime`].
 
 use mime_const::index::Mime;
-// use mime_const::rfc7231::ParseError;
 
 #[test]
-fn const_display_lowercase() {
+fn display_const_lowercase() {
     assert_eq!(
-        Mime::constant("text/plain; charset=utf-8").to_string(),
-        "text/plain; charset=utf-8"
+        Mime::try_constant("text/plain; charset=utf-8").map(|m| m.to_string()),
+        Ok("text/plain; charset=utf-8".to_owned()),
     );
 }
 
 #[test]
-fn new_display_lowercase() {
+fn display_new_lowercase() {
     assert_eq!(
-        Mime::new("text/plain; charset=utf-8").unwrap().to_string(),
-        "text/plain; charset=utf-8"
+        Mime::new("text/plain; charset=utf-8").map(|m| m.to_string()),
+        Ok("text/plain; charset=utf-8".to_owned())
     );
 }
 
-/*
-#[ignore = "no case support"]
 #[test]
-#[should_panic]
-fn const_display_uppercase() {
+fn display_const_mixed_case() {
     assert_eq!(
-        Mime::try_constant("TEXT/PLAIN; CHARSET=UTF-8"),
-        Err(ParseError::UppercaseType { pos: 0, byte: b'T' })
+        Mime::try_constant("Text/SGML; CharSet=UTF-8").map(|m| m.to_string()),
+        Ok("Text/SGML; CharSet=UTF-8".to_owned()),
     );
 }
-*/
 
-#[ignore = "no case support"]
 #[test]
-fn new_display_uppercase() {
+fn display_new_mixed_case() {
     assert_eq!(
-        Mime::new("TEXT/PLAIN; CHARSET=UTF-8").unwrap().to_string(),
-        "text/plain; charset=utf-8"
+        Mime::new("Text/SGML; CharSet=UTF-8").map(|m| m.to_string()),
+        Ok("Text/SGML; CharSet=UTF-8".to_owned())
+    );
+}
+
+#[test]
+fn display_const_extra_spaces() {
+    assert_eq!(
+        Mime::try_constant("text/plain  ;   charset=utf-8")
+            .map(|m| m.to_string()),
+        Ok("text/plain; charset=utf-8".to_owned()),
+    );
+}
+
+#[test]
+fn display_new_extra_spaces() {
+    assert_eq!(
+        Mime::new("text/plain   ;  charset=utf-8").map(|m| m.to_string()),
+        Ok("text/plain; charset=utf-8".to_owned())
+    );
+}
+
+#[test]
+fn display_const_no_spaces() {
+    assert_eq!(
+        Mime::try_constant("text/plain;charset=utf-8").map(|m| m.to_string()),
+        Ok("text/plain; charset=utf-8".to_owned()),
+    );
+}
+
+#[test]
+fn display_new_no_spaces() {
+    assert_eq!(
+        Mime::new("text/plain;charset=utf-8").map(|m| m.to_string()),
+        Ok("text/plain; charset=utf-8".to_owned())
     );
 }

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -66,3 +66,51 @@ fn display_new_no_spaces() {
         Ok("text/plain; charset=utf-8".to_owned())
     );
 }
+
+#[test]
+fn eq_const_spaces() {
+    assert_eq!(
+        Mime::try_constant("text/plain;charset=utf-8"),
+        Mime::try_constant("text/plain   ; charset=utf-8")
+    );
+}
+
+#[test]
+fn eq_new_spaces() {
+    assert_eq!(
+        Mime::new("text/plain;charset=utf-8"),
+        Mime::new("text/plain   ; charset=utf-8")
+    );
+}
+
+#[test]
+fn eq_const_parameters() {
+    assert_eq!(
+        Mime::try_constant("a/b; k1=v1; k2=v2"),
+        Mime::try_constant("a/b; k2=v2; k1=v1")
+    );
+}
+
+#[test]
+fn ne_const_parameters_different_len() {
+    assert_ne!(
+        Mime::try_constant("a/b; k1=v1; k2=v2"),
+        Mime::try_constant("a/b; k1=v1")
+    );
+}
+
+#[test]
+fn eq_const_mixed_case() {
+    assert_eq!(
+        Mime::try_constant("A/b; K1=v1; k2=v2"),
+        Mime::try_constant("a/B; K2=v2; k1=v1")
+    );
+}
+
+#[test]
+fn ne_const_mixed_case_parameter_values() {
+    assert_ne!(
+        Mime::try_constant("a/b; k1=V1; k2=v2"),
+        Mime::try_constant("a/b; k1=v1; k2=v2")
+    );
+}


### PR DESCRIPTION
- **Test that `index::Mime` passes case through as is, but normalizes spaces.**
  

- **Lints: various pedantic fixes.**
  

- **`Eq` and `PartialEq` for `index::Mime`.**
  